### PR TITLE
Fix error caused by missing directory

### DIFF
--- a/track.py
+++ b/track.py
@@ -1,5 +1,6 @@
 import numpy.linalg
 from time import time
+import os
 
 ITERATIONS = 5
 
@@ -62,6 +63,8 @@ def draw(arr, filename):
 					blah = True
 			if not blah:
 				tmp[i][j] = image[i][j]
+	if not os.path.exists("images/"):
+		os.makedirs("images/")
 	fout = open("images/" + filename,"w")
 	fout.write(str(thing)+"\n")
 	fout.write(str(width)+"\n")


### PR DESCRIPTION
I'm sure in your local copy you have 'images/", however, empty directories are not included in the github repo. IE, after cloning your project and attempting to run it, an error was thrown in function:draw because it could not run the following line:

fout = open("images/" + filename,"w")

My patch fixes this issue.
